### PR TITLE
Sequel 5.0.0 compatibility

### DIFF
--- a/lib/sequel/extensions/savepoint_hooks/version.rb
+++ b/lib/sequel/extensions/savepoint_hooks/version.rb
@@ -2,6 +2,6 @@
 
 module Sequel
   module SavepointHooks
-    VERSION = '0.1.0'
+    VERSION = '0.2.0'
   end
 end

--- a/sequel-savepoint-hooks.gemspec
+++ b/sequel-savepoint-hooks.gemspec
@@ -24,5 +24,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'minitest-hooks', '~> 1.2.0'
   spec.add_development_dependency 'pg'
 
-  spec.add_dependency 'sequel', '~> 4.35'
+  spec.add_dependency 'sequel', '~> 5.0'
 end


### PR DESCRIPTION
Sequel 5.0.0 was released.
Allow compatibility with sequel from 5.0.0 onwards.